### PR TITLE
 Enable downloading feature. Change release process,service, and acti…

### DIFF
--- a/aslo/models/release.py
+++ b/aslo/models/release.py
@@ -9,8 +9,7 @@ class ReleaseModel(AsloBaseModel):
     activity_version = me.FloatField(required=True)
     release_notes = me.StringField(required=True)
     min_sugar_version = me.FloatField(required=True)
-    # Also known as xo_url
-    download_url = me.URLField(required=True)
+    bundle_name = me.StringField(required=True)
     is_web = me.BooleanField(required=True, default=False)
     is_gtk3 = me.BooleanField(required=True, default=False)
     has_old_toolbars = me.BooleanField(required=False, default=False)

--- a/aslo/service/activity.py
+++ b/aslo/service/activity.py
@@ -74,7 +74,7 @@ def insert_activity(data):
     release.min_sugar_version = float(data['sugar']['min_sugar_version'])
     release.is_web = data['sugar']['is_web']
     release.has_old_toolbars = data['sugar']['has_old_toolbars']
-    release.download_url = 'https://mock.org/download_url'
+    release.bundle_name = data['bundle_name']
     release.release_notes = data['release']['notes']
     release.timestamp = data['release']['time']
     release.screenshots = data['screenshots']

--- a/aslo/web/templates/elements/activity_detail_card.html
+++ b/aslo/web/templates/elements/activity_detail_card.html
@@ -6,7 +6,7 @@
       <img src="data:{{ activity.icon_type }};base64,{{ activity.icon|b64encode }}" alt="Loading image..." class="center-block"/>
     </div>
     <footer class="card-footer">
-      <a class="btn btn-raised btn-md btn-success" href="{{ current_release.download_url }}"> <i class="fa fa-arrow-down"></i>{{ _('Download') }}</a>
+      <a class="btn btn-raised btn-md btn-success" href="{{ url_for('web.serve_bundle', bundle_id=activity.bundle_id, bundle_name=current_release.bundle_name) }}"> <i class="fa fa-arrow-down"></i>{{ _('Download') }}</a>
       {% if activity.previous_releases|count != 0 %}
         <div class="btn-group">
           <a href="javascript:void(0)" class="btn btn-primary btn-md btn-raised">{{ _('More Releases') }}</a>

--- a/aslo/web/templates/elements/front_card.html
+++ b/aslo/web/templates/elements/front_card.html
@@ -4,7 +4,7 @@
     <h3>{{ activity.name.get(lang_code, activity.name.get('en', activity.name.get('en_US', _('No Translation') ))) }}</h3>
     <img width="80px" height="80px" src="data:{{ activity.icon_type }};base64,{{ activity.icon|b64encode }}" alt="Loading image..." class="center-block img-fluid" />
     <footer class="card-footer">
-      <a class="btn btn-raised btn-success waves-effect" href="{{ activity.latest_release.download_url }}"> <i class="fa fa-arrow-down"></i>{{ _('Download') }}</a>
+      <a class="btn btn-raised btn-success waves-effect" href="{{ url_for('web.serve_bundle', bundle_id=activity.bundle_id, bundle_name=activity.latest_release.bundle_name) }}"> <i class="fa fa-arrow-down"></i>{{ _('Download') }}</a>
       <a class="btn btn-raised btn-primary waves-effect" href="{{ url_for('web.activity_detail', bundle_id=activity.bundle_id, activity_version=activity.latest_release.activity_version) }}"> <i class="fa fa-chevron-right" aria-hidden="true"></i>{{ _('More') }}</a>
     </footer>
   </div>

--- a/aslo/web/views.py
+++ b/aslo/web/views.py
@@ -1,10 +1,12 @@
 from . import web
 from flask import (render_template,
                    abort, request, redirect,
-                   url_for, flash, session)
+                   url_for, flash, session, send_from_directory)
+from flask import current_app as app
 from aslo.persistence.activity import Activity
 from aslo.service import activity as activity_service
 from flask_babel import gettext
+import os
 
 
 @web.route('/', defaults={'page': 1})
@@ -56,3 +58,14 @@ def search(page=1, items_per_page=10):
     flash(gettext("Search Results for {}").format(name), 'success')
     return render_template('index.html', activities=activities,
                            search_query=name, lang_code=lang_code)
+
+
+@web.route("/downloads/<bundle_id>/<bundle_name>")
+def serve_bundle(bundle_id, bundle_name):
+    bundle_location = os.path.join(app.config['BUILD_BUNDLE_DIR'], bundle_id)
+    file_location = os.path.join(bundle_location, bundle_name)
+    if os.path.exists(file_location):
+        return send_from_directory(bundle_location, bundle_name)
+    else:
+        flash("{} doesn't exists".format(bundle_name), 'error')
+        return redirect(url_for('web.index'))


### PR DESCRIPTION
 Enable downloading feature. Change release process,service, and activity model

Removed `download_url` from the model and replaced it `bundle_name`

For webhook based releases, all bundles will be stored in `BUILD_BUNDLE_DIR` inside their  respective `bundle_id` directory.
If bundle exists, download dialog will appear 
![screenshot from 2017-08-24 17-21-09](https://user-images.githubusercontent.com/2412081/29665185-a621d7c6-88f0-11e7-89ad-4d8ea2563e7e.png)


If bundle doesn't exists. aslo-v3 will flash the error 
![screenshot from 2017-08-24 16-26-10](https://user-images.githubusercontent.com/2412081/29665155-806218e8-88f0-11e7-8130-9f5b2ee77115.png)
