### PR TITLE
Fix package build failures

### DIFF
--- a/aslo/api/gh.py
+++ b/aslo/api/gh.py
@@ -44,4 +44,4 @@ def comment_on_commit(commit, message):
 def render_markdown(message):
     # https://developer.github.com/v3/markdown/
     g = auth()
-    return g.render_markdown(message).decode()
+    return g.render_markdown(message)


### PR DESCRIPTION
Aslov3-devel was failing while creating packages due to changes in the [ underlying wrappers of render_markdown of PyGithub] (https://github.com/PyGithub/PyGithub/blob/master/github/MainClass.py#L571)  (I suspect) in the upstream, which was causing folllowing errors in build phase

```bash
Traceback (most recent call last):
05:08:54 worker.1 |   File "/srv/www/aslo3-devel/env/lib/python3.5/site-packages/celery/app/trace.py", line 382, in trace_task
05:08:54 worker.1 |     R = retval = fun(*args, **kwargs)
05:08:54 worker.1 |   File "/srv/www/aslo3-devel/aslo/celery_app.py", line 16, in __call__
05:08:54 worker.1 |     return TaskBase.__call__(self, *args, **kwargs)
05:08:54 worker.1 |   File "/srv/www/aslo3-devel/env/lib/python3.5/site-packages/celery/app/trace.py", line 641, in __protected_call__
05:08:54 worker.1 |     return self.run(*args, **kwargs)
05:08:54 worker.1 |   File "/srv/www/aslo3-devel/aslo/api/tasks.py", line 10, in release_process
05:08:54 worker.1 |     handle_release(gh_json)
05:08:54 worker.1 |   File "/srv/www/aslo3-devel/aslo/api/release.py", line 345, in handle_release
05:08:54 worker.1 |     gh_json['release']['body']
05:08:54 worker.1 |   File "/srv/www/aslo3-devel/aslo/api/gh.py", line 47, in render_markdown
05:08:54 worker.1 |     return g.render_markdown(message).decode()
05:08:54 worker.1 | AttributeError: 'str' object has no attribute 'decode'

```

Removing the redudant decode fixed it